### PR TITLE
Use ssize_t in notty-cairo to support 32-bit systems.

### DIFF
--- a/notty-cairo/Cargo.toml
+++ b/notty-cairo/Cargo.toml
@@ -9,6 +9,7 @@ gdk = "0.2.0"
 gdk-pixbuf-sys = "0.2.1"
 gio-sys = "0.2.1"
 itertools = "0.4.4"
+libc = "0.1"
 
 [dependencies.notty]
 path = ".."

--- a/notty-cairo/src/image_renderer.rs
+++ b/notty-cairo/src/image_renderer.rs
@@ -8,6 +8,7 @@ use gdk::cairo_interaction::ContextExt;
 use gdk::glib::translate::FromGlibPtr;
 use gio;
 use pixbuf;
+use libc;
 
 use notty::terminal::Styles;
 
@@ -22,7 +23,7 @@ impl ImageRenderer {
         fn pixbuf_from_data(data: &[u8]) -> Option<Pixbuf> {
             let null = ptr::null_mut();
             unsafe {
-                let (data, len) = (mem::transmute(data.as_ptr()), data.len() as i64);
+                let (data, len) = (mem::transmute(data.as_ptr()), data.len() as libc::ssize_t);
                 let stream = gio::g_memory_input_stream_new_from_data(data, len, None);
                 let pixbuf = pixbuf::gdk_pixbuf_new_from_stream(stream, null, null as *mut _);
                 if pixbuf != null as *mut _ { Some(Pixbuf::from_glib_full(pixbuf)) }

--- a/notty-cairo/src/lib.rs
+++ b/notty-cairo/src/lib.rs
@@ -3,6 +3,7 @@ extern crate gdk;
 extern crate gdk_pixbuf_sys as pixbuf;
 extern crate gio_sys as gio;
 extern crate itertools;
+extern crate libc;
 extern crate notty;
 extern crate pangocairo;
 


### PR DESCRIPTION
Closes #18
