### PR TITLE
Prepare to allow configuration without recompilation

### DIFF
--- a/notty-cairo/src/lib.rs
+++ b/notty-cairo/src/lib.rs
@@ -12,7 +12,7 @@ mod text_renderer;
 
 use itertools::Itertools;
 
-use notty::cfg;
+use notty::cfg::CONFIG;
 use notty::datatypes::Color;
 use notty::terminal::{CharCell, Terminal};
 
@@ -37,7 +37,7 @@ impl Renderer {
     }
 
     pub fn draw(&self, terminal: &Terminal, canvas: &cairo::Context) {
-        let Color(r,g,b) = cfg::DEFAULT_BG;
+        let Color(r,g,b) = CONFIG.bg_color;
         canvas.set_source_rgb(color(r), color(g), color(b));
         canvas.paint();
 

--- a/notty-cairo/src/text_renderer.rs
+++ b/notty-cairo/src/text_renderer.rs
@@ -15,7 +15,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::ops::Range;
 
-use notty::cfg;
+use notty::cfg::CONFIG;
 use notty::datatypes::Color;
 use notty::terminal::Styles;
 
@@ -81,17 +81,17 @@ impl TextRenderer {
         canvas.move_to(self.x_pos, self.y_pos);
 
         // Set text color
-        let Color(r,g,b) = cfg::DEFAULT_FG;
+        let Color(r,g,b) = CONFIG.bg_color;
         canvas.set_source_rgb(color(r), color(g), color(b));
 
         // Draw the text
         let cairo = canvas.to_glib_none();
-        PangoLayout::new(cairo.0, cfg::FONT, &self.text, self.pango_attrs()).show(cairo.0);
+        PangoLayout::new(cairo.0, CONFIG.font, &self.text, self.pango_attrs()).show(cairo.0);
     }
 
     fn is_blank(&self) -> bool {
         self.text.chars().all(char::is_whitespace)
-        && self.bg_color.iter().all(|&(_, color)| color == cfg::DEFAULT_BG)
+        && self.bg_color.iter().all(|&(_, color)| color == CONFIG.bg_color)
     }
 
     fn add_style(&mut self, range: &Range<usize>, style: Styles) {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -15,30 +15,46 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use datatypes::Color;
 
+pub struct Config {
+    pub font: &'static str,
+    pub scrollback: u32,
+    pub tab_stop: u32,
+    pub fg_color: Color,
+    pub bg_color: Color,
+    pub cursor_color: Color,
+    pub colors: [Color; 256]
+}
+
+pub const CONFIG: Config = Config {
+    font: FONT,
+    scrollback: SCROLLBACK,
+    tab_stop: TAB_STOP,
+    fg_color: DEFAULT_FG,
+    bg_color: DEFAULT_BG,
+    cursor_color: CURSOR_COLOR,
+    colors: COLORS_256,
+};
+
 // FONTS
 
 pub const FONT: &'static str = "Inconsolata 10";
 
-// LOGGING
-
-pub const LOGFILE: &'static str = "~/.log/notty";
-
 // SCOLLBACK
 
-pub const SCROLLBACK: u32 = 512;
+const SCROLLBACK: u32 = 512;
 
 // TABS
 
-pub const TAB_STOP: u32 = 4;
+const TAB_STOP: u32 = 4;
 
 // COLORS
 
-pub const DEFAULT_FG: Color = Color(0xff,0xff,0xff);
-pub const DEFAULT_BG: Color = Color(0x00,0x00,0x00);
+const DEFAULT_FG: Color = Color(0xff,0xff,0xff);
+const DEFAULT_BG: Color = Color(0x00,0x00,0x00);
 
-pub const CURSOR_COLOR: Color = Color(0xbb,0xbb,0xbb);
+const CURSOR_COLOR: Color = Color(0xbb,0xbb,0xbb);
 
-pub const COLORS_256: [Color; 256] = [
+const COLORS_256: [Color; 256] = [
     /*  0    */ Color(0x00,0x00,0x00),
     /*  1    */ Color(0x55,0x55,0xff),
     /*  2    */ Color(0x55,0xff,0x55),

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -17,28 +17,28 @@ use datatypes::Color;
 
 // FONTS
 
-pub static FONT: &'static str = "Inconsolata 10";
+pub const FONT: &'static str = "Inconsolata 10";
 
 // LOGGING
 
-pub static LOGFILE: &'static str = "~/.log/notty";
+pub const LOGFILE: &'static str = "~/.log/notty";
 
 // SCOLLBACK
 
-pub static SCROLLBACK: u32 = 512;
+pub const SCROLLBACK: u32 = 512;
 
 // TABS
 
-pub static TAB_STOP: u32 = 4;
+pub const TAB_STOP: u32 = 4;
 
 // COLORS
 
-pub static DEFAULT_FG: Color = Color(0xff,0xff,0xff);
-pub static DEFAULT_BG: Color = Color(0x00,0x00,0x00);
+pub const DEFAULT_FG: Color = Color(0xff,0xff,0xff);
+pub const DEFAULT_BG: Color = Color(0x00,0x00,0x00);
 
-pub static CURSOR_COLOR: Color = Color(0xbb,0xbb,0xbb);
+pub const CURSOR_COLOR: Color = Color(0xbb,0xbb,0xbb);
 
-pub static COLORS_256: [Color; 256] = [
+pub const COLORS_256: [Color; 256] = [
     /*  0    */ Color(0x00,0x00,0x00),
     /*  1    */ Color(0x55,0x55,0xff),
     /*  2    */ Color(0x55,0xff,0x55),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -13,9 +13,6 @@
 //  
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-use std::fs::File;
-use std::io::Write;
-
 use command::prelude::*;
 
 mod erase;
@@ -79,9 +76,6 @@ pub struct NoFeature(pub String);
 
 impl Command for NoFeature {
     fn apply(&self, _: &mut Terminal) -> io::Result<()> {
-        if let Ok(mut file) = File::open(::cfg::LOGFILE) {
-            let _ = write!(file, "{}", self.repr());
-        }
         Ok(())
     }
     fn repr(&self) -> String {

--- a/src/datatypes/iter.rs
+++ b/src/datatypes/iter.rs
@@ -31,7 +31,7 @@ pub struct CoordsIter {
 
 impl CoordsIter {
 
-    pub fn from_area(area: Area, cursor: Coords, screen: Region) -> CoordsIter {
+    pub fn from_area(area: Area, cursor: Coords, screen: Region, tab: u32) -> CoordsIter {
         match area {
             CursorCell              => CoordsIter {
                 point: cursor,
@@ -56,13 +56,13 @@ impl CoordsIter {
             },
             CursorTo(mov)           => CoordsIter {
                 point: cursor,
-                back_point: move_within(cursor, mov, screen),
+                back_point: move_within(cursor, mov, screen, tab),
                 region: screen,
                 dir: mov.direction(cursor),
                 fin: false,
             },
             CursorBound(coords) if coords == cursor => {
-                CoordsIter::from_area(CursorCell, cursor, screen)
+                CoordsIter::from_area(CursorCell, cursor, screen, tab)
             }
             CursorBound(coords)     => {
                 CoordsIter::from_region(Region::new(cursor.x, cursor.y, coords.x, coords.y))
@@ -124,7 +124,7 @@ impl Iterator for CoordsIter {
                 Some(self.point)
             }
             (false, _)  => {
-                let point = move_within(self.point, To(self.dir, 1, true), self.region);
+                let point = move_within(self.point, To(self.dir, 1, true), self.region, 0);
                 Some(mem::replace(&mut self.point, point))
             }
         }
@@ -146,7 +146,8 @@ impl DoubleEndedIterator for CoordsIter {
                 Some(self.point)
             }
             (false, _)  => {
-                let point = move_within(self.back_point, To(self.dir.rev(), 1, true), self.region);
+                let point = move_within(self.back_point, To(self.dir.rev(), 1, true), self.region,
+                                        0);
                 Some(mem::replace(&mut self.back_point, point))
             }
         }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -21,8 +21,6 @@ use std::cmp;
 
 use mime::Mime;
 
-use cfg;
-
 mod iter;
 mod key;
 
@@ -82,7 +80,7 @@ pub enum Code {
 }
 
 /// Calculate the movement from one coordinate to another within a region.
-pub fn move_within(Coords {x, y}: Coords, movement: Movement, region: Region) -> Coords {
+pub fn move_within(Coords {x, y}: Coords, movement: Movement, region: Region, tab: u32) -> Coords {
     use self::Movement::*;
     use self::Direction::*;
     match movement {
@@ -150,11 +148,11 @@ pub fn move_within(Coords {x, y}: Coords, movement: Movement, region: Region) ->
             unimplemented!()
         }
         Tab(Left, n, _)                 => {
-            let tab = ((x / cfg::TAB_STOP).saturating_sub(n)) * cfg::TAB_STOP;
+            let tab = ((x / tab).saturating_sub(n)) * tab;
             Coords {x: cmp::max(tab, region.left), y: y}
         }
         Tab(Right, n, _)                => {
-            let tab = ((x / cfg::TAB_STOP) + n) * cfg::TAB_STOP;
+            let tab = ((x / tab) + n) * tab;
             Coords {x: cmp::min(tab, region.right - 1), y: y}
         }
         Tab(..)                             => unimplemented!(),

--- a/src/terminal/char_grid/cursor.rs
+++ b/src/terminal/char_grid/cursor.rs
@@ -48,7 +48,7 @@ impl Cursor {
             }
             _   => (),
         }
-        let mut coords = move_within(self.coords, movement, grid.bounds());
+        let mut coords = move_within(self.coords, movement, grid.bounds(), cfg::TAB_STOP);
 
         if let CharCell::Extension(source, _) = grid[coords] {
             match movement {
@@ -71,7 +71,8 @@ impl Cursor {
             match movement.direction(self.coords) {
                 Up | Left                   => self.coords = source,
                 dir @ Down | dir @ Right    => loop {
-                    let next_coords = move_within(coords, To(dir, 1, false), grid.bounds());
+                    let next_coords = move_within(coords, To(dir, 1, false), grid.bounds(),
+                                                  cfg::TAB_STOP);
                     if next_coords == coords { self.coords = source; return; }
                     if let CharCell::Extension(source2, _) = grid[next_coords] {
                         if source2 != source { self.coords = source2; return; }

--- a/src/terminal/char_grid/cursor.rs
+++ b/src/terminal/char_grid/cursor.rs
@@ -13,7 +13,7 @@
 //  
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-use cfg;
+use cfg::CONFIG;
 use datatypes::{Coords, Movement, move_within};
 use datatypes::Direction::*;
 use datatypes::Movement::*;
@@ -48,7 +48,7 @@ impl Cursor {
             }
             _   => (),
         }
-        let mut coords = move_within(self.coords, movement, grid.bounds(), cfg::TAB_STOP);
+        let mut coords = move_within(self.coords, movement, grid.bounds(), CONFIG.tab_stop);
 
         if let CharCell::Extension(source, _) = grid[coords] {
             match movement {
@@ -72,7 +72,7 @@ impl Cursor {
                 Up | Left                   => self.coords = source,
                 dir @ Down | dir @ Right    => loop {
                     let next_coords = move_within(coords, To(dir, 1, false), grid.bounds(),
-                                                  cfg::TAB_STOP);
+                                                  CONFIG.tab_stop);
                     if next_coords == coords { self.coords = source; return; }
                     if let CharCell::Extension(source2, _) = grid[next_coords] {
                         if source2 != source { self.coords = source2; return; }
@@ -91,7 +91,7 @@ impl Default for Cursor {
         Cursor {
             coords: Coords::default(),
             style: Styles {
-                fg_color: cfg::CURSOR_COLOR,
+                fg_color: CONFIG.cursor_color,
                 ..Styles::default()
             },
             text_style: Styles::default(),

--- a/src/terminal/char_grid/mod.rs
+++ b/src/terminal/char_grid/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use unicode_width::*;
 
-use cfg;
+use cfg::CONFIG;
 use datatypes::{Area, CellData, Coords, CoordsIter, Direction, Movement, Region, Style, move_within};
 use datatypes::Area::*;
 use datatypes::Movement::*;
@@ -48,7 +48,7 @@ impl CharGrid {
     pub fn new(w: u32, h: u32, scroll_x: bool, scroll_y: bool) -> CharGrid {
         let grid = match (scroll_x, scroll_y) {
             (false, false)  => Grid::new(w as usize, h as usize),
-            (false, true)   => Grid::with_y_cap(w as usize, h as usize, cfg::SCROLLBACK as usize),
+            (false, true)   => Grid::with_y_cap(w as usize, h as usize, CONFIG.scrollback as usize),
             (true, false)   => unimplemented!(),
             (true, true)    => unimplemented!(),
         };
@@ -102,7 +102,7 @@ impl CharGrid {
                 let mut coords = self.cursor.coords;
                 for _ in 1..width {
                     let next_coords = move_within(coords, To(Right, 1, false), bounds,
-                                                  cfg::TAB_STOP);
+                                                  CONFIG.tab_stop);
                     if next_coords == coords { break; } else { coords = next_coords; }
                     self.grid[coords] = CharCell::Extension(self.cursor.coords,
                                                             self.cursor.text_style);
@@ -119,11 +119,11 @@ impl CharGrid {
             }
             CellData::Image { pos, width, height, data, mime }   => {
                 let mut end = self.cursor.coords;
-                end = move_within(end, To(Right, width, false), self.grid.bounds(), cfg::TAB_STOP);
-                end = move_within(end, To(Down, height, false), self.grid.bounds(), cfg::TAB_STOP);
+                end = move_within(end, To(Right, width, false), self.grid.bounds(), CONFIG.tab_stop);
+                end = move_within(end, To(Down, height, false), self.grid.bounds(), CONFIG.tab_stop);
                 let mut iter = CoordsIter::from_area(CursorBound(end),
                                                      self.cursor.coords, self.grid.bounds(),
-                                                     cfg::TAB_STOP);
+                                                     CONFIG.tab_stop);
                 if let Some(cu_coords) = iter.next() {
                     self.grid[cu_coords] = CharCell::image(data, mime, pos, width, height,
                                                            self.cursor.text_style);
@@ -166,7 +166,7 @@ impl CharGrid {
         let mut iter = CoordsIter::from_area(CursorTo(ToEdge(Right)),
                                              self.cursor.coords,
                                              self.grid.bounds(),
-                                             cfg::TAB_STOP);
+                                             CONFIG.tab_stop);
         iter.next();
         for coords in iter.rev().skip(n as usize) {
             self.grid.moveover(coords, Coords {x: coords.x + n, y: coords.y});
@@ -252,7 +252,7 @@ impl CharGrid {
 
     fn in_area<F>(&mut self, area: Area, f: F) where F: Fn(&mut Grid<CharCell>, Coords) {
         for coords in CoordsIter::from_area(area, self.cursor.coords, self.grid.bounds(),
-                                            cfg::TAB_STOP) {
+                                            CONFIG.tab_stop) {
             f(&mut self.grid, coords);
         }
     }
@@ -272,7 +272,7 @@ mod tests {
 
     use super::*;
 
-    use cfg;
+    use cfg::CONFIG;
     use datatypes::{CellData, Coords, Direction, Movement};
 
     fn run_test<F: Fn(CharGrid, u32)>(test: F) {
@@ -323,7 +323,7 @@ mod tests {
         run_test(|mut grid, h| {
             let movements = vec![
                 (Movement::ToEdge(Direction::Down), Coords {x:0, y:9}),
-                (Movement::Tab(Direction::Right, 1, false), Coords{x:cfg::TAB_STOP, y:9}),
+                (Movement::Tab(Direction::Right, 1, false), Coords{x:CONFIG.tab_stop, y:9}),
                 (Movement::NextLine(1), Coords{x:0, y:h-1}),
             ];
             for (mov, coords) in movements {

--- a/src/terminal/char_grid/mod.rs
+++ b/src/terminal/char_grid/mod.rs
@@ -101,7 +101,8 @@ impl CharGrid {
                 let bounds = self.grid.bounds();
                 let mut coords = self.cursor.coords;
                 for _ in 1..width {
-                    let next_coords = move_within(coords, To(Right, 1, false), bounds);
+                    let next_coords = move_within(coords, To(Right, 1, false), bounds,
+                                                  cfg::TAB_STOP);
                     if next_coords == coords { break; } else { coords = next_coords; }
                     self.grid[coords] = CharCell::Extension(self.cursor.coords,
                                                             self.cursor.text_style);
@@ -118,10 +119,11 @@ impl CharGrid {
             }
             CellData::Image { pos, width, height, data, mime }   => {
                 let mut end = self.cursor.coords;
-                end = move_within(end, To(Right, width, false), self.grid.bounds());
-                end = move_within(end, To(Down, height, false), self.grid.bounds());
+                end = move_within(end, To(Right, width, false), self.grid.bounds(), cfg::TAB_STOP);
+                end = move_within(end, To(Down, height, false), self.grid.bounds(), cfg::TAB_STOP);
                 let mut iter = CoordsIter::from_area(CursorBound(end),
-                                                     self.cursor.coords, self.grid.bounds());
+                                                     self.cursor.coords, self.grid.bounds(),
+                                                     cfg::TAB_STOP);
                 if let Some(cu_coords) = iter.next() {
                     self.grid[cu_coords] = CharCell::image(data, mime, pos, width, height,
                                                            self.cursor.text_style);
@@ -163,7 +165,8 @@ impl CharGrid {
     pub fn insert_blank_at(&mut self, n: u32) {
         let mut iter = CoordsIter::from_area(CursorTo(ToEdge(Right)),
                                              self.cursor.coords,
-                                             self.grid.bounds());
+                                             self.grid.bounds(),
+                                             cfg::TAB_STOP);
         iter.next();
         for coords in iter.rev().skip(n as usize) {
             self.grid.moveover(coords, Coords {x: coords.x + n, y: coords.y});
@@ -248,7 +251,8 @@ impl CharGrid {
     }
 
     fn in_area<F>(&mut self, area: Area, f: F) where F: Fn(&mut Grid<CharCell>, Coords) {
-        for coords in CoordsIter::from_area(area, self.cursor.coords, self.grid.bounds()) {
+        for coords in CoordsIter::from_area(area, self.cursor.coords, self.grid.bounds(),
+                                            cfg::TAB_STOP) {
             f(&mut self.grid, coords);
         }
     }

--- a/src/terminal/char_grid/styles.rs
+++ b/src/terminal/char_grid/styles.rs
@@ -13,7 +13,7 @@
 //  
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-use cfg;
+use cfg::CONFIG;
 use datatypes::{Color, Style};
 use datatypes::Style::*;
 
@@ -45,11 +45,11 @@ impl Styles {
             Blink(flag)             => self.blink = flag,
             Opacity(n)              => self.opacity = n,
             FgColor(color)          => self.fg_color = color,
-            FgColorCfg(Some(n))     => self.fg_color = cfg::COLORS_256[n as usize],
-            FgColorCfg(None)        => self.fg_color = cfg::DEFAULT_FG,
+            FgColorCfg(Some(n))     => self.fg_color = CONFIG.colors[n as usize],
+            FgColorCfg(None)        => self.fg_color = CONFIG.fg_color,
             BgColor(color)          => self.bg_color = color,
-            BgColorCfg(Some(n))     => self.bg_color = cfg::COLORS_256[n as usize],
-            BgColorCfg(None)        => self.bg_color = cfg::DEFAULT_BG,
+            BgColorCfg(Some(n))     => self.bg_color = CONFIG.colors[n as usize],
+            BgColorCfg(None)        => self.bg_color = CONFIG.bg_color,
         }
     }
 }
@@ -57,8 +57,8 @@ impl Styles {
 impl Default for Styles {
     fn default() -> Styles {
         Styles {
-            fg_color:           cfg::DEFAULT_FG,
-            bg_color:           cfg::DEFAULT_BG,
+            fg_color:           CONFIG.fg_color,
+            bg_color:           CONFIG.bg_color,
             opacity:            0xff,
             bold:               false,
             italic:             false,
@@ -74,7 +74,7 @@ impl Default for Styles {
 #[cfg(test)]
 mod tests {
 
-    use cfg;
+    use cfg::CONFIG;
     use datatypes::Color;
     use datatypes::Style::*;
     use super::*;
@@ -103,9 +103,9 @@ mod tests {
         assert_eq!(style.bg_color, Color(0x10, 0x10, 0x10));
 
         style.update(FgColorCfg(None));
-        assert_eq!(style.fg_color, cfg::DEFAULT_FG);
+        assert_eq!(style.fg_color, CONFIG.fg_color);
         style.update(BgColorCfg(None));
-        assert_eq!(style.bg_color, cfg::DEFAULT_BG);
+        assert_eq!(style.bg_color, CONFIG.bg_color);
     }
 
 }


### PR DESCRIPTION
1. Within `notty`, the `cfg` module is only accessed directly from the `terminal` module.
2. All config information is stored on a `Config` struct and not made public directly.

These both have the same motivation - they will make it easier to store non-static config information directly on the `Terminal` struct. This will allow config info to be loaded at runtime, so it can be changed by the user without them having to recompile notty from the source.
