### PR TITLE
#30 Fix Ctrl-D termination behavior.

### DIFF
--- a/scaffolding/src/commands.rs
+++ b/scaffolding/src/commands.rs
@@ -9,8 +9,6 @@ use gtk::{self, WidgetTrait};
 use notty::Command;
 use notty::terminal::Terminal;
 
-use exit_on_io_error;
-
 pub struct CommandApplicator {
     rx: Receiver<Command>,
     terminal: Rc<RefCell<Terminal>>,
@@ -32,7 +30,9 @@ impl CommandApplicator {
             match self.rx.try_recv() {
                 Ok(cmd)             => {
                     redraw = true;
-                    terminal.apply(&cmd).unwrap_or_else(exit_on_io_error);
+                    terminal.apply(&cmd).unwrap_or_else(|_| {
+                        gtk::main_quit();
+                    });
                 }
                 Err(Disconnected)   => {
                     gtk::main_quit();

--- a/scaffolding/src/commands.rs
+++ b/scaffolding/src/commands.rs
@@ -36,7 +36,6 @@ impl CommandApplicator {
                 }
                 Err(Disconnected)   => {
                     gtk::main_quit();
-                    panic!();
                 }
                 Err(Empty)          => break,
             }

--- a/scaffolding/src/commands.rs
+++ b/scaffolding/src/commands.rs
@@ -1,9 +1,10 @@
 use std::cell::RefCell;
+use std::io;
 use std::rc::Rc;
+use std::result;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::TryRecvError::*;
 
-use gdk;
 use gtk::{self, WidgetTrait};
 
 use notty::Command;
@@ -15,6 +16,13 @@ pub struct CommandApplicator {
     canvas: Rc<gtk::DrawingArea>,
 }
 
+pub enum CommandError {
+    Io(io::Error),
+    Disconnected,
+}
+
+pub type Result<T> = result::Result<T, CommandError>;
+
 impl CommandApplicator {
 
     pub fn new(rx: Receiver<Command>,
@@ -23,25 +31,26 @@ impl CommandApplicator {
         CommandApplicator { rx: rx, terminal: terminal, canvas: canvas }
     }
 
-    pub fn apply(&self) -> gdk::glib::Continue {
+    pub fn apply(&self) -> Result<()> {
         let mut terminal = self.terminal.borrow_mut();
         let mut redraw = false;
         loop {
             match self.rx.try_recv() {
                 Ok(cmd)             => {
+                    match terminal.apply(&cmd) {
+                        Err(e) => return Err(CommandError::Io(e)),
+                        _ => {},
+                    }
                     redraw = true;
-                    terminal.apply(&cmd).unwrap_or_else(|_| {
-                        gtk::main_quit();
-                    });
-                }
+                },
                 Err(Disconnected)   => {
-                    gtk::main_quit();
-                }
+                    return Err(CommandError::Disconnected);
+                },
                 Err(Empty)          => break,
             }
         }
         if redraw { self.canvas.queue_draw(); }
-        gdk::glib::Continue(true)
+        Ok(())
     }
 
 }


### PR DESCRIPTION
Specifically set up a GTK main timeout function to periodically check an
Arc<AtmoicBool> value that indicates whether a read on the pty in the listening
thread fails--this failure is taken to mean that the process on the other side
of the pseudoterminal has exited.

Also improve error handling in CommandApplicator.
Also decrease timeout for CommandApplicatior::apply() calls to improve
responsiveness to keystrokes (notice difference between 125 and 25 milliseconds
when holding down a character in scaffolding)
