### PR TITLE
Make Command more opaque.

### DIFF
--- a/scaffolding/src/commands.rs
+++ b/scaffolding/src/commands.rs
@@ -12,14 +12,14 @@ use notty::terminal::Terminal;
 use exit_on_io_error;
 
 pub struct CommandApplicator {
-    rx: Receiver<Box<Command>>,
+    rx: Receiver<Command>,
     terminal: Rc<RefCell<Terminal>>,
     canvas: Rc<gtk::DrawingArea>,
 }
 
 impl CommandApplicator {
 
-    pub fn new(rx: Receiver<Box<Command>>,
+    pub fn new(rx: Receiver<Command>,
                terminal: Rc<RefCell<Terminal>>,
                canvas: Rc<gtk::DrawingArea>) -> CommandApplicator {
         CommandApplicator { rx: rx, terminal: terminal, canvas: canvas }
@@ -32,7 +32,7 @@ impl CommandApplicator {
             match self.rx.try_recv() {
                 Ok(cmd)             => {
                     redraw = true;
-                    cmd.apply(&mut terminal).unwrap_or_else(exit_on_io_error);
+                    terminal.apply(&cmd).unwrap_or_else(exit_on_io_error);
                 }
                 Err(Disconnected)   => {
                     gtk::main_quit();

--- a/scaffolding/src/key.rs
+++ b/scaffolding/src/key.rs
@@ -15,30 +15,22 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use gdk::EventKey;
-use notty::{Command, KeyPress, KeyRelease};
 use notty::datatypes::Key;
 
-pub trait FromEvent {
-    fn from_event(&EventKey) -> Option<Box<Command>>;
-}
-
-impl FromEvent for KeyPress {
-    fn from_event(key: &EventKey) -> Option<Box<Command>> {
-        Some(Box::new(KeyPress(keyval(key.keyval))) as Box<Command>)
-    }
-}
-
-impl FromEvent for KeyRelease {
-    fn from_event(key: &EventKey) -> Option<Box<Command>> {
-        if super_mode(key) && (key.keyval == 0xff52 || key.keyval == 0xff54) {
-            return None;
-        }
-        Some(Box::new(KeyRelease(keyval(key.keyval))) as Box<Command>)
+pub fn key_from_event(event: &EventKey) -> Option<Key> {
+    if super_mode(event) && (event.keyval == 0xff52 || event.keyval == 0xff54) && release(event) {
+        None
+    } else {
+        Some(keyval(event.keyval))
     }
 }
 
 fn super_mode(key: &EventKey) -> bool {
     key.state.bits() & 0o100 == 0o100
+}
+
+fn release(key: &EventKey) -> bool {
+    key._type == ::gdk::EventType::KeyRelease
 }
 
 fn keyval(n: u32) -> Key {

--- a/scaffolding/src/main.rs
+++ b/scaffolding/src/main.rs
@@ -31,7 +31,7 @@ use std::thread;
 
 use gtk::{WindowTrait, WidgetTrait, WidgetSignals, ContainerTrait};
 
-use notty::{Output, Command, KeyPress, KeyRelease};
+use notty::{Output, Command};
 use notty::terminal::Terminal;
 use notty_cairo::Renderer;
 
@@ -39,7 +39,6 @@ mod commands;
 mod key;
 
 use commands::CommandApplicator;
-use key::FromEvent;
 
 static mut X_PIXELS: Option<u32> = None;
 static mut Y_PIXELS: Option<u32> = None;
@@ -99,7 +98,7 @@ fn main() {
 
     // Connect signal to receive key presses.
     window.connect_key_press_event(move |window, event| {
-        if let Some(cmd) = KeyPress::from_event(event) {
+        if let Some(cmd) = key::key_from_event(event).map(Command::key_press) {
             tx_key_press.send(cmd).unwrap();
         } else { window.queue_draw(); }
         gtk::signal::Inhibit(false)
@@ -107,7 +106,7 @@ fn main() {
 
     // Connect signal to receive key releases.
     window.connect_key_release_event(move |window, event| {
-        if let Some(cmd) = KeyRelease::from_event(event) {
+        if let Some(cmd) = key::key_from_event(event).map(Command::key_release) {
             tx_key_release.send(cmd).unwrap();
         } else { window.queue_draw(); }
         gtk::signal::Inhibit(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,35 @@ mod grapheme_tables;
 mod output;
 pub mod terminal;
 
-pub use command::{Command, KeyPress, KeyRelease};
 pub use output::Output;
+
+use command::{KeyPress, KeyRelease, CommandTrait};
+use datatypes::Key;
+
+/// A command to be applied to the terminal.
+///
+/// `Command` is an opaque wrapper type around the various commands, which does not allow for
+/// introspection or reflection. The `Output` iterator generates `Command` objects transmitted from
+/// the output of the controlling process. User input is also represented as a command, and
+/// constructors exist for creating `Command` objects with the correct internal representation for
+/// different kinds of user input.
+///
+/// Commands are passed to the `Terminal` with the `apply` method.
+pub struct Command {
+    inner: Box<CommandTrait>,
+}
+
+impl Command {
+    /// Create a command representing a key press event.
+    pub fn key_press(key: Key) -> Command {
+        Command {
+            inner: Box::new(KeyPress(key)) as Box<CommandTrait>,
+        }
+    }
+    /// Create a command representing a key release event.
+    pub fn key_release(key: Key) -> Command {
+        Command {
+            inner: Box::new(KeyRelease(key)) as Box<CommandTrait>,
+        }
+    }
+}

--- a/src/output/ansi.rs
+++ b/src/output/ansi.rs
@@ -16,6 +16,7 @@
 use std::cell::RefCell;
 use std::mem;
 
+use Command;
 use command::*;
 use datatypes::Code;
 use datatypes::args::*;
@@ -47,7 +48,7 @@ impl AnsiData {
         self.args.clear();
     }
 
-    pub fn csi(&self, terminal: char) -> Option<Box<Command>> {
+    pub fn csi(&self, terminal: char) -> Option<Command> {
         macro_rules! command_series {
             ($cmds:expr) => (wrap(CommandSeries(self.args.iter().filter_map($cmds).collect())))
         }
@@ -309,7 +310,7 @@ impl AnsiData {
     }
 
     #[allow(unused, dead_code)]
-    pub fn dcs(&self, strarg: &str) -> Option<Box<Command>> {
+    pub fn dcs(&self, strarg: &str) -> Option<Command> {
         match (self.private_mode, self.preterminal) {
             ('|', '\0')   => unimplemented!(),
             ('$', 'q')    => unimplemented!(),
@@ -319,7 +320,7 @@ impl AnsiData {
         }
     }
 
-    pub fn osc(&mut self) -> Option<Box<Command>> {
+    pub fn osc(&mut self) -> Option<Command> {
         match self.arg(0, 0) {
             0...2   =>  {
                 let title = mem::replace(&mut self.arg_buf, String::new());
@@ -351,6 +352,6 @@ impl AnsiData {
 
 }
 
-fn wrap<T: Command>(cmd: T) -> Option<Box<Command>> {
-    Some(Box::new(cmd) as Box<Command>)
+fn wrap<T: CommandTrait>(cmd: T) -> Option<Command> {
+    Some(Command { inner: Box::new(cmd) as Box<CommandTrait> })
 }

--- a/src/output/notty/mod.rs
+++ b/src/output/notty/mod.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 
 use mime::{Mime, SubLevel};
 
+use Command;
 use command::*;
 use datatypes::args::*;
 
@@ -33,7 +34,7 @@ pub struct NottyData {
 
 impl NottyData {
 
-    pub fn parse(&self) -> Option<Box<Command>> {
+    pub fn parse(&self) -> Option<Command> {
         let mut args = self.args.split(';');
         match u32::decode(args.next(), None) {
             Some(0x14)  => {
@@ -146,6 +147,6 @@ fn image<I: Iterator<Item=Vec<u8>>>(mut attachments: I) -> Option<(Mime, Vec<u8>
     })
 }
 
-fn wrap<T: Command>(cmd: Option<T>) -> Option<Box<Command>> {
-    cmd.map(|cmd| Box::new(cmd) as Box<Command>)
+fn wrap<T: CommandTrait>(cmd: Option<T>) -> Option<Command> {
+    cmd.map(|cmd| Command { inner: Box::new(cmd) as Box<CommandTrait> })
 }

--- a/src/terminal/input/mod.rs
+++ b/src/terminal/input/mod.rs
@@ -15,7 +15,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use std::io::{self, Write};
 
-use command::Command;
+use Command;
 use datatypes::{InputSettings, Key};
 
 mod buffer;
@@ -69,7 +69,7 @@ impl Input {
         self.tty.set_winsize(width as u16, height as u16)
     }
 
-    pub fn write(&mut self, key: Key, press: bool) -> io::Result<Option<Box<Command>>> {
+    pub fn write(&mut self, key: Key, press: bool) -> io::Result<Option<Command>> {
         if key.is_modifier() { self.modifiers.apply(&key, press); }
         let key = if self.modifiers.ctrl() { key.ctrl_modify() } else { key };
         self.mode.write(key, press, &mut self.tty, self.modifiers)
@@ -87,7 +87,7 @@ pub enum InputMode {
 impl InputMode {
 
     pub fn write(&mut self, key: Key, press: bool, tty: &mut Write, modifiers: Modifiers)
-            -> io::Result<Option<Box<Command>>> {
+            -> io::Result<Option<Command>> {
         match *self {
             Ansi(app_mode) if press && !key.is_modifier() => {
                 if let Some(data) = ansi::encode(&key, app_mode, modifiers) {

--- a/src/terminal/input/screen_echo.rs
+++ b/src/terminal/input/screen_echo.rs
@@ -15,6 +15,7 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 use unicode_width::*;
 
+use Command;
 use command::*;
 use datatypes::{EchoSettings, Key};
 use datatypes::Key::*;
@@ -31,12 +32,12 @@ impl ScreenEcho {
         ScreenEcho { settings: settings }
     }
 
-    pub fn echo(&self, key: Key) -> Option<Box<Command>> {
+    pub fn echo(&self, key: Key) -> Option<Command> {
         match key {
             Char(c) if c == self.settings.lerase as char  => {
                 wrap(CommandSeries(vec![
-                    Box::new(Move::new(ToEdge(Left))) as Box<Command>,
-                    Box::new(Erase::new(CursorRow)) as Box<Command>,
+                    Command { inner: Box::new(Move::new(ToEdge(Left))) as Box<CommandTrait> },
+                    Command { inner: Box::new(Erase::new(CursorRow)) as Box<CommandTrait> },
                 ]))
             }
             Char(c) if c == self.settings.lnext as char   => unimplemented!(),
@@ -49,8 +50,12 @@ impl ScreenEcho {
             Enter       => wrap(Move::new(NextLine(1))),
             Backspace   => {
                 wrap(CommandSeries(vec![
-                    Box::new(Move::new(To(Left, 1, false))) as Box<Command>,
-                    Box::new(RemoveChars::new(1)) as Box<Command>,
+                    Command {
+                        inner: Box::new(Move::new(To(Left, 1, false))) as Box<CommandTrait>
+                    },
+                    Command {
+                        inner: Box::new(RemoveChars::new(1)) as Box<CommandTrait>
+                    }
                 ]))
             }
             PageUp      => wrap(Move::new(PreviousLine(25))),
@@ -63,6 +68,6 @@ impl ScreenEcho {
     }
 }
 
-fn wrap<T: Command>(cmd: T) -> Option<Box<Command>> {
-    Some(Box::new(cmd) as Box<Command>)
+fn wrap<T: CommandTrait>(cmd: T) -> Option<Command> {
+    Some(Command { inner: Box::new(cmd) as Box<CommandTrait> })
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -20,6 +20,7 @@ use std::ops::{Deref, DerefMut};
 mod char_grid;
 mod input;
 
+use Command;
 use datatypes::{InputSettings, Key};
 
 pub use self::char_grid::{CharCell, CharGrid, Cursor, Grid, Styles, Tooltip, ImageData};
@@ -28,8 +29,8 @@ pub use self::input::Tty;
 use self::input::Input;
 
 pub struct Terminal {
-    pub width: u32,
-    pub height: u32,
+    width: u32,
+    height: u32,
     title: String,
     active: CharGrid,
     inactive: Vec<CharGrid>,
@@ -51,6 +52,10 @@ impl Terminal {
         }
     }
 
+    pub fn apply(&mut self, cmd: &Command) -> io::Result<()> {
+        cmd.inner.apply(self)
+    }
+
     pub fn send_input(&mut self, key: Key, press: bool) -> io::Result<()> {
         if let Some(cmd) = try!(match key {
             Key::DownArrow | Key::UpArrow | Key::Enter if press => {
@@ -66,7 +71,7 @@ impl Terminal {
             }
             _           => self.tty.write(key, press),
         }) {
-            try!(cmd.apply(self));
+            try!(cmd.inner.apply(self));
         }
         Ok(())
     }


### PR DESCRIPTION
In order to eventually make `Terminal` an opaque type, commands need to
be passed to a terminal method, instead of calling methods on terminal
publicly. Additionally, proper local echo support will require a certain
consistent dispatch when commands are applied, unless they are applied
internally. This refactor changes no behavior, but is a step toward
reducing the public API of the notty library.
