### PR TITLE
Fix build warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #![feature(pub_restricted)]
-#![feature(io, iter_arith)]
+#![feature(io)]
 
 extern crate base64;
 extern crate mime;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -13,7 +13,7 @@
 //  
 //  You should have received a copy of the GNU Affero General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-use std::io::{self, Write};
+use std::io::{self};
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::Ordering::Relaxed;
 


### PR DESCRIPTION
`cargo build` currently produces two warnings with easy fixes.
The `iter_arith` feature is now stable and there was an unused import.
